### PR TITLE
Changing the db-port in .env did not work, fixed that.

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,8 +7,8 @@ The api that supports the fapinstructor client.
 ## Setup
 
 1. Configure your `.env` file under server. Use `.env.example` as a reference
-2. Start the docker containers `make start`. This will build and start the docker container with an attached log watcher.
-3. Application is ready for HTTP requests `localhost:3000/`
+2. Start the docker containers `make dev`. This will build and start the docker container with an attached log watcher.
+3. Application is ready for HTTP requests `localhost:9000/`
 
 ## Debugging
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,7 +12,7 @@ services:
     command:
       [
         "./scripts/wait-for-it.sh",
-        "$DB_HOST:$DB_PORT",
+        "$DB_HOST:5432",
         "--",
         "./node_modules/.bin/nodemon",
         "--inspect=0.0.0.0:9229",
@@ -56,7 +56,7 @@ services:
     image: postgres:12.2-alpine
     restart: always
     ports:
-      - $DB_PORT:$DB_PORT
+      - $DB_PORT:5432
     environment:
       POSTGRES_USER: $DB_USER
       POSTGRES_PASSWORD: $DB_PASSWORD

--- a/knexfile.js
+++ b/knexfile.js
@@ -12,7 +12,7 @@ const defaultConfig = {
   client: "pg",
   connection: {
     host: DB_HOST,
-    port: DB_PORT,
+    port: 5432,
     user: DB_USER,
     password: DB_PASSWORD,
     database: DB_DATABASE,


### PR DESCRIPTION
Not sure about the README.md change, I could only access the api via port 9000 even though the log says its started on 3000. Maybe I've missed something there?