### PR TITLE
Fixed Gallery scraping

### DIFF
--- a/src/lib/db/reddit.js
+++ b/src/lib/db/reddit.js
@@ -217,7 +217,7 @@ function parseGallery(media_metadata) {
     .map(({ e: imageType, s: image }) => {
       if (imageType === "Image") {
         // Get the image and remove the amp; occurrences within it
-        return image && image.u && image.u.replace(/amp;/g, "");
+        return image && image.u && image.u.replace(/amp;/g, "").replace("preview", "i");
       }
     })
     // Remove any undefined entries.


### PR DESCRIPTION
Added replace from 'preview' to 'i'
Reddit returns an incorect link for gallery pictures

![1](https://user-images.githubusercontent.com/100796689/156424080-5aa6c1dd-517e-43ed-a4cc-de2560543502.png)

![2](https://user-images.githubusercontent.com/100796689/156424094-39197811-7d83-452f-90d2-1951cedddfee.png)

![3](https://user-images.githubusercontent.com/100796689/156424101-10c33aee-6f5e-4f7e-9c26-0f93c83f2f2a.png)

![4](https://user-images.githubusercontent.com/100796689/156424106-e07d0d45-c2d9-4a68-82f9-03e1e639626d.png)

![5](https://user-images.githubusercontent.com/100796689/156424115-6ee474d3-1e1e-472e-a5db-d47ce303c724.png)

