### PR TITLE
Client-side RedGifs Support

### DIFF
--- a/src/lib/db/reddit.js
+++ b/src/lib/db/reddit.js
@@ -156,7 +156,7 @@ async function resolveLinks(links) {
             )
             .catch(error => {
               // Don't log 400 errors. This usually happens when the file is removed from targeted site.
-              const is400SeriesCode = /4[0-9]{2}/.test(error.response.status);
+              const is400SeriesCode = /4[0-9]{2}/.test(error?.response?.status ?? error?.status ?? '');
               if (!is400SeriesCode) {
                 unresolvedLinks.push({ link, error: error.toString() });
               }

--- a/src/lib/media-type.js
+++ b/src/lib/media-type.js
@@ -159,6 +159,10 @@ function isGif(extension) {
   return gifs.includes(extension);
 }
 
+function isRedGif(file) {
+  return file.includes("redgifs.com");
+}
+
 const MEDIA_TYPE = {
   UNKNOWN: 0,
   PICTURE: 1,
@@ -177,6 +181,9 @@ function getMediaType(file) {
   }
   if (isGif(extension)) {
     return MEDIA_TYPE.GIF;
+  }
+  if (isRedGif(file)) {
+    return MEDIA_TYPE.VIDEO;
   }
 
   throw new Error(`Unsupported media type: ${file}`);

--- a/src/lib/scrappers/index.js
+++ b/src/lib/scrappers/index.js
@@ -5,7 +5,7 @@ const { fetchGfycat, GfycatDomain } = require("./fetchGfycat");
 const fetchers = {
   "imgur.com": fetchImgur,
   "gfycat.com": fetchGfycat(GfycatDomain.gfycat),
-  "redgifs.com": fetchGfycat(GfycatDomain.redgif),
+  "redgifs.com": url => Promise.resolve(url),
   "redd.it": url => Promise.resolve(url),
 };
 


### PR DESCRIPTION
These are the corresponding changes required to add RedGifs support using client-side lookup.

I've removed the RedGifs URL parsing as that will now be done on the client-side, and added support for RedGifs URLs without extensions to the media type parser as video types so they don't result in an error.

I've also updated the image resolution error handling to better handle errors that aren't directly from an HTTP request as I noticed a bunch of errors caused by "Cannot read property 'status' of undefined" that were caused by the existing error handling.